### PR TITLE
Fix: BoardPlanner 10개제한추가

### DIFF
--- a/src/main/java/codestates/main007/boardPlanner/BoardPlannerService.java
+++ b/src/main/java/codestates/main007/boardPlanner/BoardPlannerService.java
@@ -30,17 +30,21 @@ public class BoardPlannerService {
 
     public void save(String accessToken, long boardId, long plannerId) {
         if (memberService.findByAccessToken(accessToken).equals(plannerService.find(plannerId).getMember())) {
-            BoardPlanner boardPlanner = BoardPlanner.builder()
-                    .board(boardService.find(boardId))
-                    .planner(plannerService.find(plannerId))
-                    .priority((int) boardId)
-                    .build();
-            List<BoardPlanner> list = boardPlannerRepository.findAllByBoardAndPlanner(boardService.find(boardId),
-                    plannerService.find(plannerId));
-            if(!list.isEmpty()){
-                boardPlannerRepository.save(boardPlanner);
+            Planner planner = plannerService.find(plannerId);
+            if (planner.getBoardPlanners().size() >= 10) {
+                throw new BusinessLogicException(ExceptionCode.PLANNER_SATURATED);
+            } else {
+                BoardPlanner boardPlanner = BoardPlanner.builder()
+                        .board(boardService.find(boardId))
+                        .planner(plannerService.find(plannerId))
+                        .priority((int) boardId)
+                        .build();
+                List<BoardPlanner> list = boardPlannerRepository.findAllByBoardAndPlanner(boardService.find(boardId),
+                        plannerService.find(plannerId));
+                if (list.isEmpty()) {
+                    boardPlannerRepository.save(boardPlanner);
+                } else throw new BusinessLogicException(ExceptionCode.BOARDPLANNER_EXISTS);
             }
-            else throw new BusinessLogicException(ExceptionCode.BOARDPLANNER_EXISTS);
         } else throw new BusinessLogicException(ExceptionCode.MEMBER_UNAUTHORIZED);
     }
 

--- a/src/main/java/codestates/main007/exception/ExceptionCode.java
+++ b/src/main/java/codestates/main007/exception/ExceptionCode.java
@@ -12,7 +12,8 @@ public enum ExceptionCode {
     COMMENT_NOT_FOUND(404,"Comment not found"),
     PLANNER_EXISTS(409,"Planner exists"),
     BOARDPLANNER_EXISTS(409,"Boardplanner exists"),
-    EXPIRED_TOKEN(401,"Expired Token")
+    EXPIRED_TOKEN(401,"Expired Token"),
+    PLANNER_SATURATED(409, "Planner is full")
     ;
     private final int status;
     private final String message;


### PR DESCRIPTION
플래너에 담길수있는 게시물을 10개로 제한하고 초과시 PLANNER_SATURATED("Planner is full")을 리턴하도록 했습니다.